### PR TITLE
fixing typo when parsing extra via params

### DIFF
--- a/src/sippy/headers/sip_via.go
+++ b/src/sippy/headers/sip_via.go
@@ -101,7 +101,7 @@ func ParseSipVia(body string, config sippy_conf.Config) ([]SipHeader, error) {
                 via.extension = val
                 via.extension_exists = true
             default:
-                via.extra_headers += ";" + sparam[1]
+                via.extra_headers += ";" + sparam[0]
                 if val != nil {
                     via.extra_headers += "=" + *val
                 }


### PR DESCRIPTION
having an single alias param in via does result in an error:
`2017-10-23 14:43:32+00 ERROR: runtime error: index out of range`