### PR TITLE
make config field accecible.

### DIFF
--- a/sippy/sip_msg.go
+++ b/sippy/sip_msg.go
@@ -668,3 +668,7 @@ func (self *sipMsg) GetSipSupported() []*sippy_header.SipSupported {
 func (self *sipMsg) GetSipDate() *sippy_header.SipDate {
     return self.sip_date
 }
+
+func (self *sipMsg) GetConfig() *sippy_conf.Config {
+    return self.config
+}


### PR DESCRIPTION
To use GetBody function to get addresses from ```sipResponse``` data.

https://github.com/sippy/go-b2bua/blob/ef6e0dcd350db87973e0851704aa28c9fa44d7f6/sippy/headers/sip_address_hf.go#L112C32-L112C32

![Screenshot 2023-10-26 at 1 28 54 PM](https://github.com/sippy/go-b2bua/assets/69574727/3d432b5a-13bc-4207-930a-58b750623362)

TT: SS-5783