### PR TITLE
Set the body field when creating an INFO event

### DIFF
--- a/sippy/cc_events.go
+++ b/sippy/cc_events.go
@@ -256,6 +256,7 @@ type CCEventInfo struct {
 func NewCCEventInfo(rtime *sippy_time.MonoTime, origin string, msg_body sippy_types.MsgBody, extra_headers ...sippy_header.SipHeader) *CCEventInfo {
     return &CCEventInfo{
         CCEventGeneric : newCCEventGeneric(rtime, origin, extra_headers...),
+        body: msg_body,
     }
 }
 


### PR DESCRIPTION
For the INFO request, the body was not copied when the event was created. So, it was not possible to get the request body when processing the event in RecvEvent of Call Controller .