### PR TITLE
Do not append IP address into Call-Id header in Random Call-Id scenario

### DIFF
--- a/sippy/headers/sip_call_id.go
+++ b/sippy/headers/sip_call_id.go
@@ -53,7 +53,7 @@ func CreateSipCallId(body string) []SipHeader {
 func (self *SipCallId) genCallId(config sippy_conf.Config) {
     buf := make([]byte, 16)
     rand.Read(buf)
-    self.CallId = hex.EncodeToString(buf) + "@" + config.GetMyAddress().String()
+    self.CallId = hex.EncodeToString(buf)
 }
 
 func NewSipCallIdFromString(call_id string) *SipCallId {


### PR DESCRIPTION
In order to avoid disclosure of IP address assigned to the system in Call-Id field, this change would get the Call-Id generated without hostname's IP at the end.